### PR TITLE
Make configurable what’s shown in the status bar

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,10 +1,39 @@
 [
-{
-	"id": "view",
-	"children":
-	[
-		{"id": "groups"},
-		{ "command": "toggle_sync_scroll", "args": {"setting": "syncScroll"}, "caption": "Sync Scroll", "checkbox": true}
-	]
-}
+  {
+  	"id": "view",
+  	"children":
+  	[
+  		{"id": "groups"},
+  		{ "command": "toggle_sync_scroll", "args": {"setting": "syncScroll"}, "caption": "Sync Scroll", "checkbox": true}
+  	]
+  },
+  {
+    "id": "preferences",
+    "children": [
+      {
+        "id": "package-settings",
+        "children": [
+          {
+            "caption": "Sync View Scroll",
+            "children": [
+              {
+                "caption": "Settings - Default",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/Sync View Scroll/Sync View Scroll.sublime-settings"
+                }
+              },
+              {
+                "caption": "Settings - User",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/User/Sync View Scroll.sublime-settings"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/Sync View Scroll.sublime-settings
+++ b/Sync View Scroll.sublime-settings
@@ -1,0 +1,4 @@
+{
+  "status_on": "[Sync ON]",
+  "status_off": ""
+}

--- a/syncscroll.py
+++ b/syncscroll.py
@@ -18,6 +18,10 @@ def initialize(view):
 	updatePos(view)
 	view.settings().clear_on_change('syncScroll') #for debug reasons
 	view.settings().add_on_change('syncScroll', updateStatus) #when syncScroll is toggled, update status bar
+	settings = sublime.load_settings('Sync View Scroll.sublime-settings')
+	status_off = settings.get('status_off')
+	if status_off:
+		view.set_status('syncScroll', status_off)
 def plugin_loaded():
 	if not 'running_synch_scroll_loop' in globals():
 		global running_synch_scroll_loop
@@ -61,12 +65,19 @@ def synch_scroll():
 
 def updateStatus():
 	# print "updateStatus"
+	settings = sublime.load_settings('Sync View Scroll.sublime-settings')
 	for window in sublime.windows():
 		for view in window.views():
 			if view.settings().get('syncScroll'):
-				view.set_status('syncScroll','[Sync ON]')
+				status_on = settings.get('status_on')
+				if status_on:
+					view.set_status('syncScroll', status_on)
 			else:
-				view.erase_status('syncScroll')
+				status_off = settings.get('status_off')
+				if status_off:
+					view.set_status('syncScroll', status_off)
+				else:
+					view.erase_status('syncScroll')
 
 class syncScrollListener(sublime_plugin.EventListener):
 	def on_activated(self, view):


### PR DESCRIPTION
If `status_off` isn’t empty it’ll be shown when syncing is disabled.

Useful with emojis to emulate icons.