### PR TITLE
Sync move to bof and eof

### DIFF
--- a/syncscroll.py
+++ b/syncscroll.py
@@ -72,10 +72,16 @@ class syncScrollListener(sublime_plugin.EventListener):
 	def on_activated(self, view):
 		global synch_scroll_current_view_object
 		synch_scroll_current_view_object = view
+		view.settings().set('origPos', view.viewport_position()[1])
 	def on_load(self,view):
 		#on load add settings to a view
 		# print ("on_load")
 		initialize(view)
+	def on_text_command(self, current_view, command_name, args):
+		if current_view.settings().get('syncScroll') and command_name == 'move_to' and args['to'] in ['bof', 'eof']:
+			for view in current_view.window().views():
+				if view.settings().get('syncScroll') and view.id() != current_view.id():
+					view.run_command(command_name, args)
 
 class ToggleSyncScrollCommand(sublime_plugin.TextCommand):
 	def run(self, edit, setting):


### PR DESCRIPTION
It’s useful to be able to go to the end or beginning of all synced files when their length differ too much.

Maybe this should be activated by a setting ?

This should be merged after https://github.com/zzjin/syncViewScroll/pull/6, L75 needs to be edited to

```
view.settings().set('origPos', view.viewport_position())
```

because of horizontal scrolling.