### PR TITLE
Remove an unused `setting` argument from ToggleSyncScroll

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,3 +1,3 @@
 [
-    {"caption": "SyncScroll: Toggle Current View Scroll Sync", "args": {"setting": "syncScroll"}, "command": "toggle_sync_scroll"}
+    {"caption": "SyncScroll: Toggle Current View Scroll Sync", "command": "toggle_sync_scroll"}
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -4,7 +4,7 @@
 	"children":
 	[
 		{"id": "groups"},
-		{ "command": "toggle_sync_scroll", "args": {"setting": "syncScroll"}, "caption": "Sync Scroll", "checkbox": true}
+		{ "command": "toggle_sync_scroll", "caption": "Sync Scroll", "checkbox": true}
 	]
 }
 ]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -19,7 +19,7 @@ Just clone this repo and put it under your sublime-text package folder.
 ## Usage
 
 1. In one View, goto `View`, check the `Sync Scroll` checkbox. (OR using command palette with 'syncscroll')
-2. Repeat step 1 on all other view you wangt to sync view
+2. Repeat step 1 on all other view you want to sync view
 3. Scroll on one of these views, the others sync scrolls.
 4. You can set `{ "keys": [your_keys_here], "command": "toggle_sync_scroll" }` in user's keymap to trigger sync scroll(thanks to [@KaduAmaral](https://github.com/KaduAmaral))
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,7 +21,7 @@ Just clone this repo and put it under your sublime-text package folder.
 1. In one View, goto `View`, check the `Sync Scroll` checkbox. (OR using command palette with 'syncscroll')
 2. Repeat step 1 on all other view you wangt to sync view
 3. Scroll on one of these views, the others sync scrolls.
-4. You can set `{ "keys": [your_keys_here], "args": {"setting": "syncScroll"}, "command": "toggle_sync_scroll" }` in user's keymap to trigger sync scroll(thanks to [@KaduAmaral](https://github.com/KaduAmaral))
+4. You can set `{ "keys": [your_keys_here], "command": "toggle_sync_scroll" }` in user's keymap to trigger sync scroll(thanks to [@KaduAmaral](https://github.com/KaduAmaral))
 
 ## Author
 zzjin tczzjin#gmail.com

--- a/syncscroll.py
+++ b/syncscroll.py
@@ -78,10 +78,10 @@ class syncScrollListener(sublime_plugin.EventListener):
 		initialize(view)
 
 class ToggleSyncScrollCommand(sublime_plugin.TextCommand):
-	def run(self, edit, setting):
+	def run(self, edit):
 		current_state = self.view.settings().get('syncScroll')
 		self.view.settings().set('syncScroll',not current_state)
-	def is_checked(self, setting):
+	def is_checked(self):
 		if not self.view.settings().has('syncScroll'):
 			initialize(self.view)
 		# print ("current setting",self.view.settings().get('syncScroll'))


### PR DESCRIPTION
This argument isn’t necessary is it ?